### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/badge.yml
+++ b/.github/workflows/badge.yml
@@ -11,14 +11,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install nightly toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
+      uses: dtolnay/rust-toolchain@nightly
     - name: Run cargo test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all --features=bincoded,derive
+      run: cargo test --all --features=bincoded,derive

--- a/.github/workflows/check-platforms.yml
+++ b/.github/workflows/check-platforms.yml
@@ -17,14 +17,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install stable toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
+      uses: dtolnay/rust-toolchain@stable
     - name: Run cargo check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --all --features=bincoded,derive
+      run: cargo check --all --features=bincoded,derive

--- a/.github/workflows/check-targets.yml
+++ b/.github/workflows/check-targets.yml
@@ -25,15 +25,10 @@ jobs:
         - x86_64-unknown-linux-gnu
         - wasm32-unknown-unknown
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install stable toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        profile: minimal
-        toolchain: stable
-        target: ${{ matrix.target }}
+        targets: ${{ matrix.target }}
     - name: Run cargo check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --all --features=bincoded,derive
+      run: cargo check --all --features=bincoded,derive

--- a/.github/workflows/check-toolchains.yml
+++ b/.github/workflows/check-toolchains.yml
@@ -17,14 +17,10 @@ jobs:
       matrix:
         rust-toolchain: [stable, nightly]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install ${{ matrix.rust-toolchain }} toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust-toolchain }}
     - name: Run cargo check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --all --features=bincoded,derive
+      run: cargo check --all --features=bincoded,derive

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -14,27 +14,19 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install nightly toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
+      uses: dtolnay/rust-toolchain@nightly
     - name: Run cargo fmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+      run: cargo fmt --all -- --check
 
   clippy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install nightly toolchain with clippy available
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@nightly
       with:
-        profile: minimal
-        toolchain: nightly
         components: rustfmt
     - name: Run cargo clippy
       uses: actions-rs/clippy-check@v1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,7 +13,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: actions-rs/audit-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-features.yml
+++ b/.github/workflows/test-features.yml
@@ -21,14 +21,10 @@ jobs:
         derive: [",derive", ""]
         bincoded: [",bincoded", ""]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install stable toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust-toolchain }}
     - name: Run cargo test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all --no-default-features --features=${{ matrix.fixed }}${{ matrix.std }}${{ matrix.derive }}${{ matrix.bincoded }}
+      run: cargo test --all --no-default-features --features=${{ matrix.fixed }}${{ matrix.std }}${{ matrix.derive }}${{ matrix.bincoded }}


### PR DESCRIPTION
The following updates are performed:
* update [`actions/checkout`](https://github.com/actions/checkout) to v4
* replace [unmaintained](https://github.com/actions-rs/toolchain/issues/216) `actions-rs/toolchain` by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain)
* replace unmaintained `actions-rs/cargo` by direct invocation of `cargo`

Still using the outdated / unmaintained actions will generate several warnings in CI runs, for example in https://github.com/zakarumych/alkahest/actions/runs/7347591734:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions-rs/toolchain@v1, actions-rs/cargo@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

The PR will get rid of those warnings.

